### PR TITLE
remove security vulnerabilities  

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "./node_modules/.bin/grunt travis"
   },
   "dependencies": {
-    "jquery": "^1.11.2"
+    "jquery": "^3.4.1"
   },
   "devDependencies": {
     "qunitjs": "^1.17.1",


### PR DESCRIPTION
With the purpose of removing security vulnerability, the version of the jquery is changed to the most current one which is 3.4.1